### PR TITLE
Generate Args in the Correct Order

### DIFF
--- a/src/CheatcodesList.tsx
+++ b/src/CheatcodesList.tsx
@@ -72,7 +72,9 @@ export const CheatcodesList = ({
     const func = flatCheatcodes[funcName].function;
     if (func) {
       const funcParams = params[funcName] || {};
-      const args = Object.values(funcParams);
+      const args = flatCheatcodes[funcName].params.map((param) => {
+        return funcParams[param.name];
+      });
       func(...args);
     }
   };
@@ -169,7 +171,9 @@ export const CheatcodesList = ({
                                       placeholder="Select an option"
                                       value={
                                         params
-                                          ? params[funcName]?.[param.name] ?? ""
+                                          ? (params[funcName]?.[
+                                              param.name
+                                            ] as string) ?? ""
                                           : param.dropdownOptions[0]
                                       }
                                       onChange={(e) =>
@@ -202,7 +206,9 @@ export const CheatcodesList = ({
                                       placeholder={param.type}
                                       value={
                                         params
-                                          ? params[funcName]?.[param.name] ?? ""
+                                          ? (params[funcName]?.[
+                                              param.name
+                                            ] as string) ?? ""
                                           : ""
                                       }
                                       onChange={(e) =>


### PR DESCRIPTION
Fixes a bug where inputting arguments in the incorrect order resulted in the function trying to call with the params in that order instead of the order of the cheatcode